### PR TITLE
Adding Check Against Password Hash for Auth in Case Password is Reset

### DIFF
--- a/src/components/core/directives/authModal.js
+++ b/src/components/core/directives/authModal.js
@@ -48,13 +48,14 @@ angular.module('common')
                     authModal.css('display', 'none');
                     content.css('display', 'block');
                     
-                    if (authService.isAuthenticated()) {
-                        return;
-                    }
-
-                    // Load password hash and show modal if needed
+                    // Load password hash first, then check authentication
                     authService.getPasswordHash()
                         .then((data) => {
+                            // Now check if already authenticated
+                            if (authService.isAuthenticated()) {
+                                return;
+                            }
+
                             if (!data) {
                                 return;
                             }
@@ -75,7 +76,8 @@ angular.module('common')
                                 const inputHash = CryptoJS.SHA256(passwordInput.val()).toString();
 
                                 if (inputHash === passwordHash) {
-                                    localStorage.setItem('openmappr_authenticated', 'true');
+                                    // Store the password hash for authentication
+                                    localStorage.setItem('openmappr_password_hash', passwordHash);
                                     window.location.reload();
                                 } else {
                                     scope.error = true;
@@ -87,7 +89,8 @@ angular.module('common')
                         .catch(function (error) {
                             console.error('Error in auth modal:', error);
                             // If there's an error, allow access
-                            localStorage.setItem('openmappr_authenticated', 'true');
+                            // Store empty hash since no password is required in error case
+                            localStorage.setItem('openmappr_password_hash', '');
                             window.location.reload();
                         });
                 }

--- a/src/products/player/ctrlApp.js
+++ b/src/products/player/ctrlApp.js
@@ -1,6 +1,6 @@
 angular.module('player')
-    .controller('AppCtrl', ['$q', '$sce', '$scope', '$rootScope', '$uibModal', '$routeParams', '$timeout', '$location', '$http', '$cookies', 'playerFactory', 'projFactory', 'dataService', 'networkService', 'clusterService', 'dataGraph', 'snapshotService', 'graphSelectionService', 'layoutService', 'searchService', 'browserDetectService', 'BROADCAST_MESSAGES', 'renderGraphfactory', 'ngIntroService', '$window',
-        function ($q, $sce, $scope, $rootScope, $uibModal, $routeParams, $timeout, $location, $http, $cookies, playerFactory, projFactory, dataService, networkService, clusterService, dataGraph, snapshotService, graphSelectionService, layoutService, searchService, browserDetectService, BROADCAST_MESSAGES, renderGraphfactory, ngIntroService, $window) {
+    .controller('AppCtrl', ['$q', '$sce', '$scope', '$rootScope', '$uibModal', '$routeParams', '$timeout', '$location', '$http', '$cookies', 'playerFactory', 'projFactory', 'dataService', 'networkService', 'clusterService', 'dataGraph', 'snapshotService', 'graphSelectionService', 'layoutService', 'searchService', 'browserDetectService', 'BROADCAST_MESSAGES', 'renderGraphfactory', 'ngIntroService', '$window', 'authService',
+        function ($q, $sce, $scope, $rootScope, $uibModal, $routeParams, $timeout, $location, $http, $cookies, playerFactory, projFactory, dataService, networkService, clusterService, dataGraph, snapshotService, graphSelectionService, layoutService, searchService, browserDetectService, BROADCAST_MESSAGES, renderGraphfactory, ngIntroService, $window, authService) {
             'use strict';
 
             /*************************************
@@ -454,7 +454,7 @@ angular.module('player')
                         console.log('[' + (Date.now() - timeStart) + '] [ctrlPlayer] player load %O', playerDoc);
                         $scope.player = playerDoc;
 
-                        const authFlag = localStorage.getItem('openmappr_authenticated')
+                        const authFlag = authService.isAuthenticated();
                         if (playerDoc.player.settings.passwordHash && !authFlag) {
                             return $q.reject('Authentication required');
                         }


### PR DESCRIPTION
We want to change the password on players. The current implementation only checks if the browser had authenticated before. This would then pass if we change the password, which we don't want.